### PR TITLE
feat: Read from meta.yml in get_components_to_install

### DIFF
--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -161,15 +161,16 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, Any]
             components = meta.get("components")
             component_list = []
             for component in components:
-                if isinstance(component, str):
-                    comp_dict = {"name": component, "org_path": None, "git_remote": None}
-                else:
-                    name = list(component.keys())[0]
-                    comp_dict = {
-                        "name": name,
-                        "org_path": component[name]["org_path"],
-                        "git_remote": component[name]["git_remote"],
-                    }
-                component_list.append(comp_dict)
+                if component not in subworkflows:
+                    if isinstance(component, str):
+                        comp_dict = {"name": component, "org_path": None, "git_remote": None}
+                    else:
+                        name = list(component.keys())[0]
+                        comp_dict = {
+                            "name": name,
+                            "org_path": component[name]["org_path"],
+                            "git_remote": component[name]["git_remote"],
+                        }
+                    component_list.append(comp_dict)
             modules.extend(component_list)
     return modules, subworkflows

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import questionary
 import rich.prompt
@@ -133,7 +133,7 @@ def prompt_component_version_sha(
     return git_sha
 
 
-def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, str | None]], List[str]]:
+def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, Any]], List[str]]:
     """
     Parse the subworkflow main.nf file to retrieve all imported modules and subworkflows.
     """

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import questionary
 import rich.prompt
@@ -133,7 +133,7 @@ def prompt_component_version_sha(
     return git_sha
 
 
-def get_components_to_install(subworkflow_dir: str) -> Tuple[List[dict], List[str]]:
+def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, str | None]], List[str]]:
     """
     Parse the subworkflow main.nf file to retrieve all imported modules and subworkflows.
     """

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 import questionary
 import rich.prompt
+import yaml
 
 import nf_core.utils
 from nf_core.modules.modules_repo import ModulesRepo
@@ -146,9 +147,10 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[str], List[str
             match = regex.match(line)
             if match and len(match.groups()) == 2:
                 name, link = match.groups()
-                if link.startswith("../../../"):
-                    name_split = name.lower().split("_")
-                    modules.append("/".join(name_split))
-                elif link.startswith("../"):
+                if link.startswith("../"):
                     subworkflows.append(name.lower())
+    with open(Path(subworkflow_dir, "meta.yml")) as fh:
+        meta = yaml.safe_load(fh)
+        components = meta.get("components")
+        modules.extend(components)
     return modules, subworkflows

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -33,6 +33,7 @@ class ComponentInstall(ComponentCommand):
         installed_by=False,
     ):
         super().__init__(component_type, pipeline_dir, remote_url, branch, no_pull)
+        self.current_remote = remote_url
         self.force = force
         self.prompt = prompt
         self.sha = sha
@@ -58,7 +59,7 @@ class ComponentInstall(ComponentCommand):
                 remote_url = component["git_remote"]
                 self.modules_repo = ModulesRepo(remote_url)
             else:
-                self.modules_repo = ModulesRepo()
+                self.modules_repo = ModulesRepo(self.current_remote)
             component = component["name"]
 
         # Verify that 'modules.json' is consistent with the installed modules and subworkflows

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -53,10 +53,13 @@ class ComponentInstall(ComponentCommand):
             # Check modules directory structure
             self.check_modules_structure()
 
+        repo_path = self.modules_repo.repo_path
+        remote_url = self.modules_repo.remote_url
         if isinstance(component, dict):
-            component_name = list(component.keys())[0]
-            self.modules_repo = ModulesRepo(component[component_name]["git_remote"])
-            component = component_name
+            if component["git_remote"] is not None:
+                repo_path = component["org_path"]
+                remote_url = component["git_remote"]
+            component = component["name"]
 
         # Verify that 'modules.json' is consistent with the installed modules and subworkflows
         modules_json = ModulesJson(self.dir)
@@ -70,61 +73,59 @@ class ComponentInstall(ComponentCommand):
             return False
 
         # Verify SHA
-        if not self.modules_repo.verify_sha(self.prompt, self.sha):
+        if not ModulesRepo(remote_url).verify_sha(self.prompt, self.sha):
             return False
 
         # Check and verify component name
-        component = self.collect_and_verify_name(component, self.modules_repo)
+        component = self.collect_and_verify_name(component, ModulesRepo(remote_url))
         if not component:
             return False
 
         # Get current version
-        current_version = modules_json.get_component_version(
-            self.component_type, component, self.modules_repo.remote_url, self.modules_repo.repo_path
-        )
+        current_version = modules_json.get_component_version(self.component_type, component, remote_url, repo_path)
 
         # Set the install folder based on the repository name
-        install_folder = Path(self.dir, self.component_type, self.modules_repo.repo_path)
+        install_folder = Path(self.dir, self.component_type, repo_path)
 
         # Compute the component directory
         component_dir = Path(install_folder, component)
 
         # Check that the component is not already installed
         component_not_installed = self.check_component_installed(
-            component, current_version, component_dir, self.modules_repo, self.force, self.prompt, silent
+            component, current_version, component_dir, ModulesRepo(remote_url), self.force, self.prompt, silent
         )
         if not component_not_installed:
             log.debug(
                 f"{self.component_type[:-1].title()} is already installed and force is not set.\nAdding the new installation source {self.installed_by} for {self.component_type[:-1]} {component} to 'modules.json' without installing the {self.component_type}."
             )
             modules_json.load()
-            modules_json.update(self.component_type, self.modules_repo, component, current_version, self.installed_by)
+            modules_json.update(
+                self.component_type, ModulesRepo(remote_url), component, current_version, self.installed_by
+            )
             return False
 
-        version = self.get_version(component, self.sha, self.prompt, current_version, self.modules_repo)
+        version = self.get_version(component, self.sha, self.prompt, current_version, ModulesRepo(remote_url))
         if not version:
             return False
 
         # Remove component if force is set and component is installed
         install_track = None
         if self.force:
-            log.debug(f"Removing installed version of '{self.modules_repo.repo_path}/{component}'")
+            log.debug(f"Removing installed version of '{repo_path}/{component}'")
             self.clear_component_dir(component, component_dir)
-            install_track = self.clean_modules_json(component, self.modules_repo, modules_json)
+            install_track = self.clean_modules_json(component, ModulesRepo(remote_url), modules_json)
         if not silent:
             log.info(f"{'Rei' if self.force else 'I'}nstalling '{component}'")
-        log.debug(
-            f"Installing {self.component_type} '{component}' at modules hash {version} from {self.modules_repo.remote_url}"
-        )
+        log.debug(f"Installing {self.component_type} '{component}' at modules hash {version} from {remote_url}")
 
         # Download component files
-        if not self.install_component_files(component, version, self.modules_repo, install_folder):
+        if not self.install_component_files(component, version, ModulesRepo(remote_url), install_folder):
             return False
 
         # Update module.json with newly installed subworkflow
         modules_json.load()
         modules_json.update(
-            self.component_type, self.modules_repo, component, version, self.installed_by, install_track
+            self.component_type, ModulesRepo(remote_url), component, version, self.installed_by, install_track
         )
 
         if self.component_type == "subworkflows":

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -14,7 +14,7 @@ from nf_core.components.components_utils import (
     prompt_component_version_sha,
 )
 from nf_core.modules.modules_json import ModulesJson
-from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME
+from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME, ModulesRepo
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +52,11 @@ class ComponentInstall(ComponentCommand):
         if self.component_type == "modules":
             # Check modules directory structure
             self.check_modules_structure()
+
+        if isinstance(component, dict):
+            component_name = list(component.keys())[0]
+            self.modules_repo = ModulesRepo(component[component_name]["git_remote"])
+            component = component_name
 
         # Verify that 'modules.json' is consistent with the installed modules and subworkflows
         modules_json = ModulesJson(self.dir)

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -1186,6 +1186,11 @@ class ModulesJson:
         dep_mods, dep_subwfs = get_components_to_install(sw_path)
 
         for dep_mod in dep_mods:
+            if isinstance(dep_mod, dict):
+                component_name = list(dep_mod.keys())[0]
+                repo = dep_mod[component_name]["git_remote"]
+                org = dep_mod[component_name]["org_path"]
+                dep_mod = component_name
             installed_by = self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"]
             if installed_by == ["modules"]:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"] = []

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -1187,10 +1187,10 @@ class ModulesJson:
 
         for dep_mod in dep_mods:
             if isinstance(dep_mod, dict):
-                component_name = list(dep_mod.keys())[0]
-                repo = dep_mod[component_name]["git_remote"]
-                org = dep_mod[component_name]["org_path"]
-                dep_mod = component_name
+                if dep_mod["git_remote"] is not None:
+                    repo = dep_mod["git_remote"]
+                    org = dep_mod["org_path"]
+                dep_mod = dep_mod["name"]
             installed_by = self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"]
             if installed_by == ["modules"]:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"] = []

--- a/tests/subworkflows/install.py
+++ b/tests/subworkflows/install.py
@@ -89,7 +89,7 @@ def test_subworkflows_install_across_organizations(self):
     # Verify that the installed_by entry was added correctly
     modules_json = ModulesJson(self.pipeline_dir)
     mod_json = modules_json.get_modules_json()
-    assert mod_json["repos"][CROSS_ORGANIZATION_URL]["modules"]["jvfe"]["prokka"]["installed_by"] == [
+    assert mod_json["repos"][CROSS_ORGANIZATION_URL]["modules"]["jvfe"]["wget"]["installed_by"] == [
         "get_genome_annotation"
     ]
 


### PR DESCRIPTION
- Changes logic in `get_components_to_install` to read a subworkflow's components from the `meta.yml` file
- Does manage to install the modules in the `get_genome_annotation` manual test over here: https://github.com/jvfe/test-subworkflow-remote/ but raises errors in the log
- Is sure to break other parts of the code as well

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
