### PR TITLE
fix: Avoid duplicate downloads in nested subworkflows

### DIFF
--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -154,7 +154,6 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, Opti
                     subworkflows.append(name.lower())
 
     if Path(subworkflow_dir, "meta.yml").exists():
-        modules = []
         with open(Path(subworkflow_dir, "meta.yml")) as fh:
             meta = yaml.safe_load(fh)
             if "components" not in meta:
@@ -162,7 +161,7 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, Opti
             components = meta.get("components")
             component_list = []
             for component in components:
-                if component not in subworkflows:
+                if component not in subworkflows and component in [d["name"] for d in modules]:
                     if isinstance(component, str):
                         comp_dict = {"name": component, "org_path": None, "git_remote": None}
                     else:
@@ -173,5 +172,5 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[Dict[str, Opti
                             "git_remote": component[name]["git_remote"],
                         }
                     component_list.append(comp_dict)
-            modules.extend(component_list)
+            modules = component_list
     return modules, subworkflows


### PR DESCRIPTION
- Addresses #3 

Modules.json test failures related to duplicate entries happens because meta.yml declares modules that are not imported in the actual subworkflow code, since they're only used in the nested subworkflow. 

![image](https://github.com/user-attachments/assets/dd61b20d-de31-493f-806f-ed5170c2871a)

This way the module gets downloaded twice, hence the longer "installed_by" in modules.json.

This PR makes it so the new installation procedure checks if a module/subwf declared in meta.yml is actually imported in main.nf, and only proceeds with installation in that case.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
