### PR TITLE
Use the power of get to skip if tests

### DIFF
--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -176,7 +176,7 @@ def get_components_to_install(
         with open(Path(subworkflow_dir, "meta.yml")) as fh:
             meta = yaml.safe_load(fh)
             if "components" in meta:
-                components = meta.get("components")
+                components = meta["components"]
                 for component in components:
                     if isinstance(component, dict):
                         component_name = list(component.keys())[0].lower()
@@ -188,7 +188,7 @@ def get_components_to_install(
                         component_dict = {
                             "org_path": org_path,
                             "git_remote": git_remote,
-                            "branch": component[component_name].get("branch", None),
+                            "branch": component[component_name].get("branch"),
                         }
 
                         current_comp_dict[component_name].update(component_dict)

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -51,13 +51,10 @@ class ComponentInstall(ComponentCommand):
 
     def install(self, component: str, silent: bool = False) -> bool:
         if isinstance(component, dict):
-            if component.get("git_remote") is not None:
-                remote_url = component.get("git_remote")
-                branch = component.get("branch")
-                self.modules_repo = ModulesRepo(remote_url, branch)
-            else:
-                self.modules_repo = ModulesRepo(self.current_remote, self.branch)
-            component = component.get("name")
+            remote_url = component.get("git_remote", self.current_remote)
+            branch = component.get("branch", self.branch)
+            self.modules_repo = ModulesRepo(remote_url, branch)
+            component = component["name"]
 
         if self.repo_type == "modules":
             log.error(f"You cannot install a {component} in a clone of nf-core/modules")

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -1255,12 +1255,9 @@ class ModulesJson:
         assert self.modules_json is not None  # mypy
         for dep_mod in dep_mods:
             name = dep_mod["name"]
-            if dep_mod.get("git_remote") is not None:
-                current_repo = dep_mod.get("git_remote", repo)
-                current_org = dep_mod.get("org_path", org)
-                installed_by = self.modules_json["repos"][current_repo]["modules"][current_org][name]["installed_by"]
-            else:
-                installed_by = self.modules_json["repos"][repo]["modules"][org][name]["installed_by"]
+            current_repo = dep_mod.get("git_remote", repo)
+            current_org = dep_mod.get("org_path", org)
+            installed_by = self.modules_json["repos"][current_repo]["modules"][current_org][name]["installed_by"]
             if installed_by == ["modules"]:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"] = []
             if sw_name not in installed_by:
@@ -1268,14 +1265,9 @@ class ModulesJson:
 
         for dep_subwf in dep_subwfs:
             name = dep_subwf["name"]
-            if dep_subwf.get("git_remote") is not None:
-                current_repo = dep_subwf.get("git_remote", repo)
-                current_org = dep_subwf.get("org_path", org)
-                installed_by = self.modules_json["repos"][current_repo]["subworkflows"][current_org][name][
-                    "installed_by"
-                ]
-            else:
-                installed_by = self.modules_json["repos"][repo]["subworkflows"][org][name]["installed_by"]
+            current_repo = dep_subwf.get("git_remote", repo)
+            current_org = dep_subwf.get("org_path", org)
+            installed_by = self.modules_json["repos"][current_repo]["subworkflows"][current_org][name]["installed_by"]
             if installed_by == ["subworkflows"]:
                 self.modules_json["repos"][repo]["subworkflows"][org][dep_subwf]["installed_by"] = []
             if sw_name not in installed_by:


### PR DESCRIPTION
Another take on #12 

Because you still had the `if` tests, many `get` seemed unnecessary.
The alternative is to take advantage of `get` to remove the need to check things in advance. Then you can use the second argument of `get` to define the value you would have used in the `else` block

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
